### PR TITLE
Fix installing Qt6 6.8.0 on Windows

### DIFF
--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -163,7 +163,9 @@ class Inputs {
           this.arch = "android_armv7";
         }
       } else if (this.host === "windows") {
-        if (compareVersions(this.version, ">=", "5.15.0")) {
+        if (compareVersions(this.version, ">=", "6.8.0")) {
+          this.arch = "win64_msvc2022_64";
+        } else if (compareVersions(this.version, ">=", "5.15.0")) {
           this.arch = "win64_msvc2019_64";
         } else if (compareVersions(this.version, "<", "5.6.0")) {
           this.arch = "win64_msvc2013_64";


### PR DESCRIPTION
Qt switched to MSVC 2022

Fixes #250 